### PR TITLE
CORE-9234: add a check constraint to ensure that the parent ID is dif…

### DIFF
--- a/src/main/constraints/18_attr_attrs.sql
+++ b/src/main/constraints/18_attr_attrs.sql
@@ -15,3 +15,10 @@ ALTER TABLE ONLY attr_attrs
 ADD CONSTRAINT attr_attrs_child_id_fkey
 FOREIGN KEY (child_id)
 REFERENCES attributes(id) ON DELETE CASCADE;
+
+--
+-- Check constraint to avoid cyclical hierarchies.
+--
+ALTER TABLE ONLY attr_attrs
+ADD CONSTRAINT attr_attrs_parent_different_from_child
+CHECK (parent_id != child_id);


### PR DESCRIPTION
…ferent from the child ID in each row of the attr_attrs table

Note: I didn't add a conversion for this update because the previous conversion will pick up this change. The one caveat is that any environments that have already been converted will have to be refreshed before the new constraint will be added.

I toyed around with checking for longer loops in the hierarchy using queries with recursive common table expressions. This doesn't work, however, because subqueries aren't allowed in check constraints. At any rate, I may or may not end up using this query to check for longer loops.

```sql
WITH
    RECURSIVE root (parent_id, child_id, display_order, n) AS (
        SELECT parent_id, child_id, display_order, 0 FROM attr_attrs
        WHERE parent_id = (
            WITH RECURSIVE node (parent_id, child_id, display_order, n) AS (
                    SELECT parent_id, child_id, display_order, 0 FROM attr_attrs
                    WHERE parent_id = '<some-attribute-identifier>'
                UNION ALL
                    SELECT p.parent_id, p.child_id, p.display_order, n.n - 1
                    FROM attr_attrs p, node n
                    WHERE p.child_id = n.parent_id
            )
            SELECT parent_id FROM node ORDER BY n LIMIT 1
        )
    UNION ALL
        SELECT c.parent_id, c.child_id, c.display_order, r.n + 1
        FROM root r, attr_attrs c
        WHERE r.child_id = c.parent_id
)
SELECT * FROM root a, root b
WHERE b.child_id = a.parent_id
AND b.n >= a.n;
```

To be honest, it's probably more effective to check for longer loops in code before updating the database, so I probably won't use this query. I spent enough time on it that I wanted to put it somewhere for posterity, though. 🤣 
